### PR TITLE
add bitzesty private scope to plugin search paths

### DIFF
--- a/plugins.js
+++ b/plugins.js
@@ -51,9 +51,12 @@ Plugin.prototype.haraka_require = function (name) {
 Plugin.prototype.core_require = Plugin.prototype.haraka_require;
 
 function plugin_search_paths (prefix, name) {
+    var private_scope = '@bitzesty/';
+
     return [
         path.resolve(prefix, 'plugins', name + '.js'),
         path.resolve(prefix, 'node_modules', 'haraka-plugin-' + name, 'package.json'),
+        path.resolve(prefix, 'node_modules', private_scope + 'haraka-plugin-' + name, 'package.json'),
         path.resolve(prefix, '..', 'haraka-plugin-' + name, 'package.json')
     ];
 }


### PR DESCRIPTION
so that we can load bitzesty's private plugin npm packages

Addresses a specific case - our plugins have been extracted to private (scoped) npm packages. We now need this scope for haraka to find our private (scoped) plugins

Changes proposed in this pull request:
- Add `@bitzesty` 's private scope to the plugin search paths

todo:
- [ ] update docs 
- [ ] update tests
